### PR TITLE
Support custom size

### DIFF
--- a/byterange.md
+++ b/byterange.md
@@ -1,11 +1,93 @@
 # mockster/byterange
 
-mockster/byterange simply prints out the `Lorem ipsum ...` sample text, pared down to the requested range or multipart ranges, with a few bells and whistles that allow you to customize its response for unit testing purposes. We make extensive use of mockster/byterange in unit testing to verify the integrity of Trickster's output after performing operations like merging disparate range parts, extracting ranges from other ranges, or from a full body, compressing adjacent ranges into a single range in the cache, etc.
+mockster/byterange simply prints out the `Lorem ipsum ...` sample text, pared down to the requested byte range or multipart ranges, with a few bells and whistles that allow you to customize its response for unit testing purposes. We make extensive use of mockster/byterange in unit testing to verify the integrity of Trickster's output after performing operations like merging disparate range parts, extracting ranges from other ranges, or from a full body, compressing adjacent ranges into a single range in the cache, etc.
+
+Provide a properly-formatted `Range` Request header, with 1 or more byte ranges.
+
+The default output body is 1224 bytes. However, you can provide a `size=32768` parameter, where the value is any value integer representing the desired byte size of the output payload. Mockster will efficiently write to the wire the `Lorem ipsum` text until the byte size is met.
+
+You can use the size parameter by itself to simply write out a very large payload for testing purposes.
+
+Or you can combine a Range request with a size parameter, and the correct header and output bytes for the provided size and ranges will be efficiently written to the wire. If you provide a `Range` request without a size parameter, the content length will be set to highest-index byte in the range.
 
 ## Supported Simulation Endpoints
 
-- `/byterange/*` (Instantaneous)
+- `/byterange/*`
 
-Any path under `/byterange/` can be requested. This way, if you are testing byte ranges with a caching layer, each test's URL can very.
+Any path under `/byterange/` can be requested. This way, if you are testing byte ranges with a caching layer, each test's URL can vary to avoid cache collisions. No matter the path provided, the response will always be the same, as described above.
 
-For examples of using mockster/byterange for Unit Testing, see the [Trickster Unit Tests](https://github.com/Comcast/trickster/blob/master/internal/proxy/engines/objectproxycache_test.go)
+Example paths:
+    - `/byterange/test/1`
+    - `/byterange/`
+    - `/byterange/tests/testCacheMissWithRange`
+
+For examples of using mockster/byterange for Unit Testing, see the [Trickster Unit Tests](https://github.com/tricksterproxy/trickster/blob/master/internal/proxy/engines/objectproxycache_test.go)
+
+## Example Usage
+
+```bash
+$ go run cmd/mockster/main.go &
+Starting up Mockster on port 8482
+
+# make a multipart range request for a 2448-byte object
+$ curl -v -H 'Range: bytes=1220-1260,1265-1270' -H 'Connection: close'  'http://0.0.0.0:8482/byterange/?size=2448'
+*   Trying 0.0.0.0...
+* TCP_NODELAY set
+* Connected to 0.0.0.0 (127.0.0.1) port 8482 (#0)
+> GET /byterange/?size=2448 HTTP/1.1
+> Host: 0.0.0.0:8482
+> User-Agent: curl/7.64.1
+> Accept: */*
+> Range: bytes=1220-1260,1265-1270
+> Connection: close
+>
+< HTTP/1.1 206 Partial Content
+< Cache-Control: max-age=60
+< Content-Type: multipart/byteranges; boundary=TestRangeServerBoundary
+< Last-Modified: Wed, 01 Jan 2020 00:00:00 UTC
+< Date: Wed, 01 Jan 2020 00:00:00 UTC
+< Content-Length: 292
+< Connection: close
+<
+--TestRangeServerBoundary
+Content-Range: bytes 1220-1260/2448
+Content-Type: text/plain; charset=utf-8
+
+m.
+
+Lorem ipsum dolor sit amet, mel alia
+--TestRangeServerBoundary
+Content-Range: bytes 1265-1270/2448
+Content-Type: text/plain; charset=utf-8
+
+nieba
+--TestRangeServerBoundary--
+* Closing connection 0
+
+# request a 500MB response of lorem ipsum text
+$ curl -v -H 'Connection: close' -o /dev/null  'http://0.0.0.0:8482/byterange/?size=524288000'
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 0.0.0.0...
+* TCP_NODELAY set
+* Connected to 0.0.0.0 (127.0.0.1) port 8482 (#0)
+> GET /byterange/?size=524288000 HTTP/1.1
+> Host: 0.0.0.0:8482
+> User-Agent: curl/7.64.1
+> Accept: */*
+> Connection: close
+>
+< HTTP/1.1 200 OK
+< Accept-Ranges: bytes
+< Cache-Control: max-age=60
+< Content-Length: 524288000
+< Content-Type: text/plain; charset=utf-8
+< Last-Modified: Wed, 01 Jan 2020 00:00:00 UTC
+< Date: Thu, 26 Mar 2020 03:33:40 GMT
+< Connection: close
+<
+{ [12050 bytes data]
+100  500M  100  500M    0     0   710M      0 --:--:-- --:--:-- --:--:--  710M
+* Closing connection 0
+
+```

--- a/cmd/mockster/main.go
+++ b/cmd/mockster/main.go
@@ -25,6 +25,11 @@ import (
 	"github.com/tricksterproxy/mockster/pkg/routes"
 )
 
+const (
+	applicationName    = "mockster"
+	applicationVersion = "1.1.0"
+)
+
 func main() {
 
 	port := "8482"
@@ -32,7 +37,7 @@ func main() {
 		port = os.Args[1]
 	}
 
-	fmt.Println("Starting up Mockster on port", port)
+	fmt.Println("Starting up", applicationName, applicationVersion, "on port", port)
 
 	err := http.ListenAndServe(fmt.Sprintf(":%s", port), routes.GetRouter())
 	if err != nil {

--- a/pkg/mocks/byterange/handler.go
+++ b/pkg/mocks/byterange/handler.go
@@ -84,16 +84,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		// if the client is revalidating and their copy is still fresh
 		// reply w/ a 304 Not Modified
 		if ims := rh.Get(hnIfModifiedSince); ims != "" {
-
 			// for testing a 200 OK only when the user sends an IMS
 			if code, ok := customStatuses[r.URL.Query().Get("ims")]; ok {
 				customCode = code
 				if code == http.StatusOK {
 					rh.Del(hnRange)
 				}
-
 			} else {
-
 				t, err := time.Parse(time.RFC1123, ims)
 				if err == nil && (!lastModified.After(t)) {
 					w.WriteHeader(http.StatusNotModified)
@@ -126,7 +123,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cl := contentLength
-
 	if v := r.URL.Query().Get("size"); v != "" {
 		if i, err := strconv.ParseInt(v, 10, 64); err == nil && i > 0 {
 			cl = i
@@ -138,11 +134,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		ranges := parseRangeHeader(cr)
 		lr := len(ranges)
 		if ranges != nil && lr > 0 {
-
 			if ranges[lr-1].end > cl {
 				cl = ranges[lr-1].end
 			}
-
 			if ranges.validate(cl) {
 				// Handle Single Range in Request
 				if lr == 1 {
@@ -152,7 +146,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 					writeRange(w, ranges[0])
 					return
 				}
-
 				// Handle Multiple Ranges in Request
 				h.Set(hnContentType, hvMultipartByteRange+separator)
 				w.WriteHeader(http.StatusPartialContent)
@@ -162,7 +155,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
 			// TODO: write correct response indictaing what was wrong with the range.
 			return
-
 		}
 	}
 

--- a/pkg/mocks/byterange/handler.go
+++ b/pkg/mocks/byterange/handler.go
@@ -18,6 +18,7 @@ package byterange
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -124,24 +125,38 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(customCode)
 	}
 
+	cl := contentLength
+
+	if v := r.URL.Query().Get("size"); v != "" {
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil && i > 0 {
+			cl = i
+		}
+	}
+
 	// Handle Range Request Cases
 	if cr := r.Header.Get(hnRange); cr != "" {
 		ranges := parseRangeHeader(cr)
 		lr := len(ranges)
 		if ranges != nil && lr > 0 {
-			if ranges.validate() {
+
+			if ranges[lr-1].end > cl {
+				cl = ranges[lr-1].end
+			}
+
+			if ranges.validate(cl) {
 				// Handle Single Range in Request
 				if lr == 1 {
-					h.Add(hnContentRange, ranges[0].contentRangeHeader())
+					h.Add(hnContentRange, ranges[0].contentRangeHeader(cl))
 					h.Set(hnContentType, contentType)
 					w.WriteHeader(http.StatusPartialContent)
-					fmt.Fprintf(w, Body[ranges[0].start:ranges[0].end+1])
+					writeRange(w, ranges[0])
 					return
 				}
+
 				// Handle Multiple Ranges in Request
 				h.Set(hnContentType, hvMultipartByteRange+separator)
 				w.WriteHeader(http.StatusPartialContent)
-				ranges.writeMultipartResponse(w)
+				ranges.writeMultipartResponse(cl, w)
 				return
 			}
 			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
@@ -151,8 +166,40 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Handle Full Body Case
-	h.Set(hnAcceptRanges, "bytes")
+	h.Set(hnContentLength, strconv.Itoa(int(cl)))
 	h.Set(hnContentType, contentType)
-	w.Write([]byte(Body))
+	h.Set(hnAcceptRanges, "bytes")
+
+	j := int64(0)
+	lb := int64(len(Body))
+
+	for int64(j) < cl {
+		if cl-j < lb {
+			w.Write([]byte(Body[:cl-j]))
+		} else {
+			w.Write([]byte(Body))
+		}
+		j += lb
+	}
+
+}
+
+func writeRange(w io.Writer, br byteRange) {
+	if br.end < contentLength {
+		w.Write([]byte(Body[br.start:br.end]))
+		return
+	}
+	cl := br.end - br.start
+	bw := int64(0)
+	offset := br.start % contentLength
+	for bw < cl {
+		left := cl - bw
+		end := contentLength
+		if left < contentLength-offset {
+			end = offset + left
+		}
+		w.Write([]byte(Body[offset:end]))
+		bw += (end - offset)
+		offset = 0
+	}
 }


### PR DESCRIPTION
this PR enables users to request any size response from mockster/byterange, instead of just the default 1224 bytes. this enables users to use the solution as an efficient, generic byte generator for testing with large payloads (e.g., for collapsed forwarding).

I also formally added the version in this PR so as to spin up an official release.